### PR TITLE
Make tests runnable in the normal way

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -42,3 +42,6 @@ class TestFeed(unittest.TestCase):
                           data=json.dumps(self.data),
                           content_type='application/json')
         self.assertEqual(len(outbox), 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added an `if __name__ == '__main__'` so that tests run when running
`python tests.py` on the command line, like on
http://flask.pocoo.org/docs/0.10/testing/#testing.
