### PR TITLE
Adding instructions for using gmail for smtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ heroku config:add MAIL_PORT=<from mail port>
 heroku config:add TO_EMAIL=<email to send to>
 ```
 
-Since the app connects to MAIL_SERVER using the TLS protocol, it's likely that MAIL_PORT will need to be 587. Here is an example configuration for using [gmail as the SMTP server](https://support.google.com/a/answer/176600?hl=en):
+Since the app connects to MAIL_SERVER using the TLS protocol, it's likely that MAIL_PORT will need to be 587. 
+
+### Using gmail as your email server
+
+Here is an example configuration for using [gmail as the SMTP server](https://support.google.com/a/answer/176600?hl=en):
 
 ```
 MAIL_USERNAME=<gmail or google apps email address to send from>
@@ -42,6 +46,10 @@ TO_EMAIL=<email to send to>
 ```
 
 Note: in order to use gmail, you will have to turn on ["Access for less secure apps"](https://support.google.com/accounts/answer/6010255) for your "from" email. If you are using 2-factor authentication, you may also have to create an [App Password](https://support.google.com/accounts/answer/185834?hl=en#ASPs). See [this gmail help page](https://support.google.com/mail/answer/14257?rd=1) for solutions to other problems you may encounter.
+
+### Testing your email configuration
+
+Regardless of what you're using for an SMTP server, you can test your email setup by running `python test.py`. If you see "OK" at the end of the output, you're good to go. 
 
 ## Step 4: Check it out!
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ heroku config:add MAIL_PORT=<from mail port>
 heroku config:add TO_EMAIL=<email to send to>
 ```
 
+Since the app connects to MAIL_SERVER using the TLS protocol, it's likely that MAIL_PORT will need to be 587. Here is an example configuration for using [gmail as the SMTP server](https://support.google.com/a/answer/176600?hl=en):
+
+```
+MAIL_USERNAME=<gmail or google apps email address to send from>
+MAIL_PASSWORD=<from email password>
+MAIL_SERVER=smtp.gmail.com
+MAIL_PORT=587
+TO_EMAIL=<email to send to>
+```
+
+Note: in order to use gmail, you will have to turn on ["Access for less secure apps"](https://support.google.com/accounts/answer/6010255) for your "from" email. If you are using 2-factor authentication, you may also have to create an [App Password](https://support.google.com/accounts/answer/185834?hl=en#ASPs). See [this gmail help page](https://support.google.com/mail/answer/14257?rd=1) for solutions to other problems you may encounter.
+
 ## Step 4: Check it out!
 
 Run ```heroku open``` to see your snazzy new site in a web browser :)


### PR DESCRIPTION
I learned how to get this app to work with gmail as an SMTP server after
seeing this pop up in the heroku logs:

```
SMTPAuthenticationError: (534, '5.7.14
\<https://accounts.google.com/signin/continue?sarp=1&scc=1&plt=AKgnsbt9\n5.7.14
5fyrM2inKhVY4XqMikj2eHHiokAMs8QCUHHspLnw7XBxotrfoevoluVAPoF\_Rqm-fQiec4\n5.7.14
G7lsexXkc5\_v6GsEMZH6A9\_Y-xyVIn0K9\_X-SEiFdnb8fn4-5BQgpBtWrLdwEDdHmWzEfx\n5.7.14
vk0rxT8bOFWuq-fUfA-yyOLK\_Ue8fNc2XU2jZTlRSm1QOa3VO08nRc99aV0Hjb6wzcsWYv\n5.7.14
YR\_P0CMzz\_dOxb7n7odEjtaSROTJs\> Please log in via your web browser
and\n5.7.14 then try again.\n5.7.14  Learn more at\n5.7.14
https://support.google.com/mail/answer/78754 107sm5305143qge.16 -
gsmtp')
```

After turning on "Access for less secure apps" in my "from" google app
email account, suddenly the emails started sending using either SSL or
TLS.

Note: I considered changing the environment variables so that the user
would pick SSL, TLS or no encryption and the app would automatically
pick 465, 587 or 25 for the port. However, since SSL is insecure and
you're asking the user to store their password as an environment
variable, I think it makes sense to force TLS. This means that you could
not even ask for the port and just set it to 587. However, this may make
the app unusable for folks who use an SMTP server that uses non-standard
ports.
